### PR TITLE
Make Composer/Packagist detect ^0.0@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.0.1-dev"
+            "dev-master": "0.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Right now it is difficult to target something reasonable with Composer for version constraints.  I believe this will make it easier for people to be able to install even when there are no stable releases, yet.

Great work on this package, btw. :) Nice touch.